### PR TITLE
Cambios en el API

### DIFF
--- a/BlockStreamAndStringNDriver.cpp
+++ b/BlockStreamAndStringNDriver.cpp
@@ -20,9 +20,9 @@ int main(){
 
 	std::ofstream out{filename, std::ios::binary};
 
-	WriteBlock(out, Person{10, PackString("Bruce")});  // Wayne
-	WriteBlock(out, Person{11, PackString("Clark")});  // Kent
-	WriteBlock(out, Person{12, PackString("Joseph")}); // Dredd
+	WriteBlock(out, Person{10, "Bruce"});  // Wayne
+	WriteBlock(out, Person{11, "Clark"});  // Kent
+	WriteBlock(out, Person{12, "Joseph"}); // Dredd
 
 	out.close();
 	
@@ -32,7 +32,7 @@ int main(){
 		if( p.id > 10 )
 			std::cout
 				<< p.id << ", "
-				<< UnpackString(p.name)
+				<< p.name.UnpackString()
 				<< '\n';
 
 	in.close();

--- a/BlockStreamAndStringNDriver.cpp
+++ b/BlockStreamAndStringNDriver.cpp
@@ -32,7 +32,7 @@ int main(){
 		if( p.id > 10 )
 			std::cout
 				<< p.id << ", "
-				<< p.name.UnpackString()
+				<< UnpackString(p.name)
 				<< '\n';
 
 	in.close();

--- a/BlockStreamAndStringNDriver.cpp
+++ b/BlockStreamAndStringNDriver.cpp
@@ -20,9 +20,9 @@ int main(){
 
 	std::ofstream out{filename, std::ios::binary};
 
-	WriteBlock(out, Person{10, "Bruce"});  // Wayne
-	WriteBlock(out, Person{11, "Clark"});  // Kent
-	WriteBlock(out, Person{12, "Joseph"}); // Dredd
+	WriteBlock(out, Person{10, PackString("Bruce")});  // Wayne
+	WriteBlock(out, Person{11, PackString("Clark")});  // Kent
+	WriteBlock(out, Person{12, PackString("Joseph")}); // Dredd
 
 	out.close();
 	

--- a/BlockStreamAndStringNTest.cpp
+++ b/BlockStreamAndStringNTest.cpp
@@ -31,6 +31,6 @@ int main(){
 	remove(filename); // c++17 // std::filesystem::remove(filename); // Remover el archivo de prueba
 	
 	// Test: Verificar que leemos lo que habíamos escrito
-	assert(     10 == p.id                 ); 
-	assert( "León" == UnpackString(p.name) );
+	assert(     10 == p.id   );
+	assert( "León" == p.name );
 }

--- a/BlockStreamAndStringNTest.cpp
+++ b/BlockStreamAndStringNTest.cpp
@@ -19,7 +19,7 @@ int main(){
 	
 	// Write
 	std::ofstream out{filename, std::ios::binary};   // Crear archivo y conectar flujo en modo binario
-	WriteBlock(out, Person{10, "León"}); // Escribir en el flujo out una Persona.
+	WriteBlock(out, Person{10, PackString("León")}); // Escribir en el flujo out una Persona.
 	out.close();                                     // Cerrar conexión.
 	
 	// Read

--- a/BlockStreamAndStringNTest.cpp
+++ b/BlockStreamAndStringNTest.cpp
@@ -19,7 +19,7 @@ int main(){
 	
 	// Write
 	std::ofstream out{filename, std::ios::binary};   // Crear archivo y conectar flujo en modo binario
-	WriteBlock(out, Person{10, PackString("León")}); // Escribir en el flujo out una Persona.
+	WriteBlock(out, Person{10, "León"}); // Escribir en el flujo out una Persona.
 	out.close();                                     // Cerrar conexión.
 	
 	// Read

--- a/StringN.h
+++ b/StringN.h
@@ -11,48 +11,76 @@ UTN FRBA */
 #include <array>
 
 // Type: String<N>
-template<std::size_t N> using String = std::array<char,N>;
+template<std::size_t N>
+class String
+{
+	private:
+		using ContainerType = std::array<char, N>;
+		using ContainerIterator = typename ContainerType::iterator;
+		using ContainerConstIterator = typename ContainerType::const_iterator;
 
-/* Builds a string from a String<N> upto its first null characater or end,
-e.g.: s=UnpackString(a) */
-template<std::size_t N> 
-inline std::string UnpackString(const String<N>& a){
-	std::string s{""};
-	
-	for(auto c : a){
-		if(c=='\0')
-			break;
-		s.push_back(c);
-	}
-	
-	return s;
-}
+	public:
+		String() = default;
 
-/* Provides the constructs to pack strings with a simple and clear syntax:
-	a=PackString(s)
-Implemantation based upon 
-http://stackoverflow.com/questions/8165659/why-cant-c-deduce-template-type-from-assignment
-*/
-struct PackString{
-	std::string theString;
-	
-	// Build from string
-	PackString(const std::string& aString) : theString(aString) {}
-	
-	// User-defined conversion: from string to String<N>
-	template<std::size_t N>
-	inline operator String<N>(){
-		String<N> aString; // undefined content
-		auto len = theString.length();
-		
-		if( len < N ){
-			theString.copy(aString.data(), len);
-			aString.at(len) = '\0'; // form aString.at(len+1) to aString.at(N-1) undefined content.
-		}else
-			theString.copy(aString.data(), N);
-			
-	    return aString;
-	}
+		// C++ implicit conversion shenanigans
+		String(const char* theCString)
+		{
+			*this = std::string{ theCString };
+		}
+
+		String(const std::string& theString)
+		{
+			*this = theString;
+		}
+
+		inline operator std::string() const
+		{
+			std::string s;
+			for (auto c : _impl)
+			{
+				if (c == '\0')
+					break;
+				s.push_back(c);
+			}
+
+			return s;
+		}
+
+		inline String<N>& operator=(const std::string& theString)
+		{
+			auto len = theString.length();
+			if (len < N)
+			{
+				theString.copy(_impl.data(), len);
+				_impl.at(len) = '\0'; // from _impl.at(len+1) to _impl.at(N-1) undefined content.
+			}
+			else
+				theString.copy(_impl.data(), N);
+
+			return *this;
+		}
+
+		inline std::string UnpackString() const
+		{
+			return std::string{ *this };
+		}
+
+		inline bool operator==(const std::string& theString) const
+		{
+			return theString == std::string{ *this };
+		}
+
+		auto begin()        -> ContainerIterator      { return _impl.begin(); }
+		auto end()          -> ContainerIterator      { return _impl.end(); }
+
+		auto begin()  const -> ContainerConstIterator { return _impl.cbegin(); }
+		auto end()    const -> ContainerConstIterator { return _impl.cend(); }
+
+		auto cbegin() const -> ContainerConstIterator { return begin(); }
+		auto cend()   const -> ContainerConstIterator { return end(); }
+
+	private:
+		ContainerType _impl;
 };
 
 #endif

--- a/StringN.h
+++ b/StringN.h
@@ -60,16 +60,6 @@ class String
 			return *this;
 		}
 
-		inline std::string UnpackString() const
-		{
-			return std::string{ *this };
-		}
-
-		inline bool operator==(const std::string& theString) const
-		{
-			return theString == std::string{ *this };
-		}
-
 		auto begin()        -> ContainerIterator      { return _impl.begin(); }
 		auto end()          -> ContainerIterator      { return _impl.end(); }
 
@@ -82,5 +72,23 @@ class String
 	private:
 		ContainerType _impl;
 };
+
+template<std::size_t N>
+inline std::string UnpackString(const String<N>& packedString)
+{
+	return std::string{ packedString };
+}
+
+template<std::size_t N>
+inline bool operator==(const String<N>& packedString, const std::string& theString)
+{
+	return theString == std::string{ packedString };
+}
+
+template<std::size_t N>
+inline bool operator==(const std::string& theString, const String<N>& packedString)
+{
+	return packedString == theString;
+}
 
 #endif

--- a/StringN.h
+++ b/StringN.h
@@ -23,12 +23,12 @@ class String
 		String() = default;
 
 		// C++ implicit conversion shenanigans
-		String(const char* theCString)
+		explicit String(const char* theCString)
 		{
 			*this = std::string{ theCString };
 		}
 
-		String(const std::string& theString)
+		explicit String(const std::string& theString)
 		{
 			*this = theString;
 		}
@@ -74,6 +74,21 @@ class String
 
 	private:
 		ContainerType _impl;
+};
+
+class PackString
+{
+	public:
+		explicit PackString(const std::string& unpackedString) : _ref{ unpackedString } { }
+
+		template<std::size_t N>
+		operator String<N>() const
+		{
+			return String<N>{ _ref };
+		}
+
+	private:
+		const std::string& _ref;
 };
 
 template<std::size_t N>

--- a/StringN.h
+++ b/StringN.h
@@ -55,13 +55,10 @@ struct String
 		{
 			const auto& theString = packString._string;
 			auto len = theString.length();
+
+			theString.copy(_impl.data(), std::min(len, N));
 			if (len < N)
-			{
-				theString.copy(_impl.data(), len);
 				_impl.at(len) = '\0'; // from _impl.at(len+1) to _impl.at(N-1) undefined content.
-			}
-			else
-				theString.copy(_impl.data(), N);
 
 			return *this;
 		}

--- a/StringN.h
+++ b/StringN.h
@@ -12,7 +12,7 @@ UTN FRBA */
 
 // Type: String<N>
 template<std::size_t N>
-class String
+struct String
 {
 	private:
 		using ContainerType = std::array<char, N>;
@@ -76,7 +76,7 @@ class String
 		ContainerType _impl;
 };
 
-class PackString
+struct PackString
 {
 	public:
 		explicit PackString(const std::string& unpackedString) : _ref{ unpackedString } { }

--- a/StringN.h
+++ b/StringN.h
@@ -33,6 +33,9 @@ class String
 			*this = theString;
 		}
 
+		char& at(std::size_t pos) { return _impl.at(pos); }
+		const char& at(std::size_t pos) const { return _impl.at(pos); }
+
 		inline operator std::string() const
 		{
 			std::string s;

--- a/StringN.h
+++ b/StringN.h
@@ -31,7 +31,7 @@ struct String
 		using ContainerConstIterator = typename ContainerType::const_iterator;
 
 	public:
-		String() = default;
+		String() : String{ PackString{ std::string{ } } } { }
 
 		String(PackString&& packString)
 		{

--- a/StringNDriver.cpp
+++ b/StringNDriver.cpp
@@ -29,14 +29,13 @@ int main(){
 	}
 
 	{ // Ejemplos
-		using std::array;
 		using std::string;
 
 		{ // String<N>
 			string    s{"Hello, World!"};
 			String<5> a{ PackString(s) };
 			string    t{a};
-			assert( t == "Hello" );
+			assert( "Hello" == t );
 		}
 
 		{ // String<N> más corto que string

--- a/StringNDriver.cpp
+++ b/StringNDriver.cpp
@@ -5,7 +5,6 @@ Profesor
 UTN FRBA */
 
 #include <string>
-#include <array>
 #include <iostream>
 #include <cassert>
 #include "StringN.h"
@@ -15,62 +14,51 @@ void PrintSizesAndContents(std::string, String<N>, std::string);
 
 int main(){
 	{ // Tests
-		{ // array más corto que string
-			std::array<char,5> a = PackString("Hello, World!");
-			assert( "Hello" == UnpackString(a) );
-		}
 		{ // String<N> más corto que string
-			String<4> s = PackString("Hello, World!");
-			assert( "Hell" == UnpackString(s) );
+			String<4> s{ "Hello, World!" };
+			assert( "Hell" == s );
 		}
 		{ // String<N> igual de largo que string
-			String<13> s = PackString("Hello, World!");
-			assert( "Hello, World!" == UnpackString(s) );
+			String<13> s{ "Hello, World!" };
+			assert( "Hello, World!" == s );
 		}
 		{ // String<N> más largo que string
-			String<42> s = PackString("Hello, World!");
-			assert( "Hello, World!" == UnpackString(s) );
+			String<42> s{ "Hello, World!" };
+			assert( "Hello, World!" == s );
 		}
 	}
-		
+
 	{ // Ejemplos
 		using std::array;
 		using std::string;
 
 		{ // String<N>
 			string    s{"Hello, World!"};
-			String<5> a = PackString(s);
-			string    t{UnpackString(a)};
+			String<5> a{ s };
+			string    t{a};
 			assert( t == "Hello" );
-		}
-		
-		{ // array<char,N>
-			string        s{"Hello, World!"};
-			array<char,5> a = PackString(s);
-			string        t{UnpackString(a)};
-			assert( t == "Hello");
 		}
 
 		{ // String<N> más corto que string
 			string s{"Texto de largo mayor a límite de registro."};
-			String<12> a = PackString(s); // array<char,12>
-			auto t{UnpackString(a)}; // desempaque todo lo que se pudo guardar
+			String<12> a{ s };
+			string t{a}; // desempaque todo lo que se pudo guardar
 			assert(s.compare(0, 12, t) == 0);
 			PrintSizesAndContents(s,a,t);
 		}
 
 		{ // String<N> igual de largo que string
 			string s{"abcd"}; // string type
-			String<4> a = PackString(s); // array<char,4> 
-			auto t{UnpackString(a)};
+			String<4> a{ s };
+			string t{a};
 			assert(s == t);
 			PrintSizesAndContents(s,a,t);
 		}
 		
 		{ // String<N> más largo que string
 			string s{"xyz"};
-			array<char,7> a = PackString(s);
-			auto t{UnpackString(a)};
+			String<7> a{ s };
+			string t{a};
 			assert(s == t);
 			PrintSizesAndContents(s,a,t);
 		}

--- a/StringNDriver.cpp
+++ b/StringNDriver.cpp
@@ -15,15 +15,15 @@ void PrintSizesAndContents(std::string, String<N>, std::string);
 int main(){
 	{ // Tests
 		{ // String<N> más corto que string
-			String<4> s{ "Hello, World!" };
+			String<4> s{ PackString("Hello, World!") };
 			assert( "Hell" == s );
 		}
 		{ // String<N> igual de largo que string
-			String<13> s{ "Hello, World!" };
+			String<13> s{ PackString("Hello, World!") };
 			assert( "Hello, World!" == s );
 		}
 		{ // String<N> más largo que string
-			String<42> s{ "Hello, World!" };
+			String<42> s{ PackString("Hello, World!") };
 			assert( "Hello, World!" == s );
 		}
 	}
@@ -34,14 +34,14 @@ int main(){
 
 		{ // String<N>
 			string    s{"Hello, World!"};
-			String<5> a{ s };
+			String<5> a{ PackString(s) };
 			string    t{a};
 			assert( t == "Hello" );
 		}
 
 		{ // String<N> más corto que string
 			string s{"Texto de largo mayor a límite de registro."};
-			String<12> a{ s };
+			String<12> a{ PackString(s) };
 			string t{a}; // desempaque todo lo que se pudo guardar
 			assert(s.compare(0, 12, t) == 0);
 			PrintSizesAndContents(s,a,t);
@@ -49,7 +49,7 @@ int main(){
 
 		{ // String<N> igual de largo que string
 			string s{"abcd"}; // string type
-			String<4> a{ s };
+			String<4> a{ PackString(s) };
 			string t{a};
 			assert(s == t);
 			PrintSizesAndContents(s,a,t);
@@ -57,7 +57,7 @@ int main(){
 		
 		{ // String<N> más largo que string
 			string s{"xyz"};
-			String<7> a{ s };
+			String<7> a{ PackString(s) };
 			string t{a};
 			assert(s == t);
 			PrintSizesAndContents(s,a,t);

--- a/StringNTest.cpp
+++ b/StringNTest.cpp
@@ -20,7 +20,7 @@ int main(){
 		int i;
 	};
 	Color c{PackString("Red")};
-	assert("Red" == UnpackString(c.s));
+	assert("Red" == c.s);
 	c.s = PackString("Blue");
-	assert("Blu" == UnpackString(c.s));
+	assert("Blu" == c.s);
 }


### PR DESCRIPTION
Cambios propuestos:

- [x] Elimina la dependencia del tipo array, al encapsularlo dentro de una clase permite mayor flexibilidad:
- [x] Empaquetar es tan sencillo como asignar un `std::string` o bien un `const char*` a.k.a. string literal (lamentablemente por limitaciones del lenguaje solo se permite ejecutar una conversión implícita a la vez, por lo que `const char*` -> `string` debe ser hecho de forma explicita)
- [x] Permite crear el `String<N>` de forma implicita (ver cambio en  WriteAndReadRecordsBlocksWithStrings.cpp)
- [x] Permite inicializar un `String<N>` con braces

- [x] Agrega conversiones de conveniencia a `std::string` y un comparador, ejemplo:
```cpp
String<4> a{ "Hello World!" };
assert( a == "Hell" );
```

- [x] `UnpackString` pasa a ser miembro de la clase `String`; si es necesario para restaurar el uso viejo se podría hacer un wrapper:

```cpp
String<4> a{ "Test" };

// old api
auto t{ UnpackString(a) };
std::cout << UnpackString(a);

std::array<char, 4> array = PackString(a);
// se pierde, si es necesario se puede hacer un operador de conversión a array<char, N>

// new api
std::string t{ a }; 
// se pierde el type inference (auto infiere el mismo tipo que a, es decir String<4>)
// aunque se puede "recuperar" mediante:
// auto inferred_t{ a.UnpackString() };

std::cout << a.UnpackString();
```

TODOs:
- [ ] Tal vez agregar directamente un operator<< de stream que permita eliminar el UnpackString